### PR TITLE
Use require.resolve to load highlight.js styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function gulpMarkdownDocs(fileOpt, opt) {
 	
 	// gather needed resources
 	var indexHtml = fs.readFileSync(options.templatePath);
-	var highlightCss = fs.readFileSync(__dirname + '/node_modules/highlight.js/styles/'+options.highlightTheme+'.css');
+	var highlightCss = fs.readFileSync(require.resolve('highlight.js/styles/'+options.highlightTheme+'.css'));
 	var layoutCss = options.layoutStylesheetUrl && fs.readFileSync(options.layoutStylesheetUrl);
 
 	// place css resources


### PR DESCRIPTION
When a project depends on `gulp-markdown-docs` and `highlight.js`, then `highlight.js` will be installed **only** in the project's `node_modules` directory. This causes the code to load the styles for the current highlighting theme fail. `require.resolve` seems to be a much safer option?
