### PR TITLE
Add Front Matter YAML format for header metadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,18 +148,19 @@ function gulpMarkdownDocs(fileOpt, opt) {
 		var markdown, meta, html;
 		if (!firstFile) firstFile = file;
 		try {
+			var parsedFile = yamlFrontMatter.loadFront(file.contents.toString());
+			var markdown = parsedFile['__content'];
+			delete parsedFile['__content'];
+			var metadata = parsedFile;
+
 			if (options.yamlMeta) {
-
-				var parsedFile = yamlFrontMatter.loadFront(file.contents.toString(), 'markdownContent');
-				console.log(parsedFile.markdownContent);
-
 				collectedDocs.push({
-					meta: parsedFile,
-					html: parseMarkdown(parsedFile.markdownContent)
+					meta: metadata,
+					html: parseMarkdown(markdown)
 				});
 			} else {
 				collectedDocs.push({
-					html: parseMarkdown(parsedFile.markdownContent)
+					html: parseMarkdown(markdown)
 				});
 			}
 		} catch (err) {

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var PluginError = gutil.PluginError;
 var fs = require('fs');
 var File = gutil.File;
 var highlight = require('highlight.js');
+var yamlFrontMatter = require('yaml-front-matter');
 
 function gulpMarkdownDocs(fileOpt, opt) {
 	if (!fileOpt) throw new PluginError('gulp-markdown-docs', 'Missing file argument for gulp-markdown-docs');
@@ -148,15 +149,17 @@ function gulpMarkdownDocs(fileOpt, opt) {
 		if (!firstFile) firstFile = file;
 		try {
 			if (options.yamlMeta) {
-				var split_text = file.contents.toString().split(/\n\n/);
-				markdown = split_text.splice(1, split_text.length-1).join('\n\n');
+
+				var parsedFile = yamlFrontMatter.loadFront(file.contents.toString(), 'markdownContent');
+				console.log(parsedFile.markdownContent);
+
 				collectedDocs.push({
-					meta:yaml.safeLoad(split_text[0]),
-					html:parseMarkdown(markdown)
+					meta: parsedFile,
+					html: parseMarkdown(parsedFile.markdownContent)
 				});
 			} else {
 				collectedDocs.push({
-					html: parseMarkdown(file.contents.toString())
+					html: parseMarkdown(parsedFile.markdownContent)
 				});
 			}
 		} catch (err) {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
     "js-yaml": "^3.2.3",
     "lodash": "^3.10.0",
     "marked": "^0.3.2",
-    "through": "^2.3.4"
+    "through": "^2.3.4",
+    "yaml-front-matter": "^3.4.0"
   },
   "devDependencies": {
+    "gulp": "^3.9.1",
     "mocha": "*",
     "should": "*",
     "stream-assert": "^2.0.1"

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ gulp.task('default', function () {
 
     yamlMeta: true
 
-*Required* in order to construct the navigation menu. When set to true, each document given to gulp-markdown-docs should have a YAML header providing needed information about the document.
+*Required* in order to construct the navigation menu. When set to true, each document given to gulp-markdown-docs should have a Front Matter YAML header providing needed information about the document.
 
 ```md
 ---
@@ -40,6 +40,7 @@ categorySlug:
 categoryLabel: 
 categoryRank: 
 documentRank: 
+---
 
 # Your Content
 ...


### PR DESCRIPTION
I have changed the way the metadata is loaded, so that the standard `Front Matter` has to be used. This is really useful for me, as I am using a CMS to change the content that use this format.

I have also tried to fix the tests, but It has been impossible :-(
